### PR TITLE
Add CSS variable example

### DIFF
--- a/src/default.sass
+++ b/src/default.sass
@@ -1,1 +1,11 @@
 @import '~bootstrap/scss/bootstrap'
+
+// Set the CSS variable --primary to the value of the bootstrap variable $primary.
+// The value of a bootstrap variable is determined at build time. After building, this
+// file will be converted to a file default.css with the content:
+//   * {
+//     --primary: #0d6efd
+//   }
+
+*
+  --primary: #{$primary}

--- a/src/solar.sass
+++ b/src/solar.sass
@@ -189,3 +189,14 @@ $btn-close-color:                       $body-color !default
 $pre-color:                         inherit !default
 
 @import '~bootstrap/scss/bootstrap'
+
+// Set the CSS variable --primary to the value of the bootstrap variable $primary.
+// The value of a bootstrap variable is determined at build time. After building, this
+// file will be converted to a file default.css with the content:
+//   * {
+//     --primary: #b58900
+//   }
+
+
+*
+  --primary: #{$primary}

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -1,1 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
+
+// Set the background color to the value of the CSS variable --primary. 
+// The value of a CSS variable may change at runtime if a different stylesheet is loaded.
+
+body
+  background-color: var(--primary) !important

--- a/src/united.scss
+++ b/src/united.scss
@@ -56,3 +56,15 @@ $table-dark-bg:               $dark !default;
 $table-dark-border-color:     darken($dark, 5%) !default;
 
 @import '~bootstrap/scss/bootstrap';
+
+// Set the CSS variable --primary to the value of the bootstrap variable $primary.
+// The value of a bootstrap variable is determined at build time. After building, this
+// file will be converted to a file default.css with the content:
+//   * {
+//     --primary: #e95420
+//   }
+
+
+* {
+  --primary: #{$primary};
+}

--- a/src/vapor.scss
+++ b/src/vapor.scss
@@ -168,3 +168,14 @@ hr:not([size]) {
 }
 
 @import '~bootstrap/scss/bootstrap';
+
+// Set the CSS variable --primary to the value of the bootstrap variable $primary.
+// The value of a bootstrap variable is determined at build time. After building, this
+// file will be converted to a file default.css with the content:
+//   * {
+//     --primary: #6f42c1
+//   }
+
+* {
+  --primary: #{$primary};
+}


### PR DESCRIPTION
This example show how to use CSS variables that change when a different theme is selected.

CSS variables can change at runtime, unlike Bootstrap variables, which are determined at compile time. 

In this example, `src/styles.sass` uses a CSS variable called `--primary`. The variable is given a different value in each theme stylesheet:
- `src/default.sass`
- `src/solar.sass`
- `src/vapor.scss`
- `src/united.scss`

Selecting a different theme will load the associated stylesheet, which will update the value of the CSS variable.